### PR TITLE
using fixed play version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = project.in( file(".") ).enablePlugins(GitVersioning)
 
 name := "toguru-scala-client"
 
-git.baseVersion := "0.2.0"
+git.baseVersion := "0.2.1"
 
 organization in ThisBuild := "com.autoscout24"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
@@ -14,7 +14,7 @@ scalaVersion in ThisBuild := "2.11.8"
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation", "-feature", "-Xfatal-warnings",
   "-Yno-adapted-args", "-Xmax-classfile-name", "130")
 
-val playVersion = "[2.5.0,2.6["
+val playVersion = "2.5.4"
 
 resolvers += Resolver.jcenterRepo
 


### PR DESCRIPTION
Relying on ivy's 'latest-version' conflict resolution mechanism.
Given the current common practice in sbt, there is no chance of using proper version constraints.
By using a fixed version, we can let the users of this lib choose their version of play as long as it is greater than 2.5.4.
The drawback of this solution is that ivy's resolution mechanism will happily use a play version 2.6.x or even 3.x.
