### PR TITLE
Adding metrics and health

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,8 @@ libraryDependencies in ThisBuild ++= Seq(
   "org.scalactic" %% "scalactic" % "2.2.5",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
+  "io.dropwizard.metrics" % "metrics-core" % "3.1.0",
+  "org.komamitsu" % "phi-accural-failure-detector" % "0.0.3",
   "com.typesafe.play" %% "play-json" % playVersion,
   "com.typesafe.play" %% "play" % playVersion % "optional",
   "com.typesafe.play" %% "play-test" % playVersion % "optional",

--- a/src/main/scala/toguru/api/Activations.scala
+++ b/src/main/scala/toguru/api/Activations.scala
@@ -5,7 +5,11 @@ import toguru.impl.RemoteActivationsProvider
 
 object Activations {
 
-  type Provider = () => Activations
+  trait Provider {
+    def apply(): Activations
+
+    def healthy(): Boolean
+  }
 
   /**
     * Creates an activation provider that polls the given endpoint url to retrieve a toggle state json.

--- a/src/main/scala/toguru/api/ToguruClient.scala
+++ b/src/main/scala/toguru/api/ToguruClient.scala
@@ -19,4 +19,11 @@ class ToguruClient[T](val clientProvider: ClientInfo.Provider[T], val activation
     */
   def apply(input: T): Toggling = TogglingInfo(clientProvider(input), activationsProvider())
 
+  /**
+    * Check whether the toguru system is healthy
+    *
+    * @return
+    */
+  def healthy(): Boolean = activationsProvider.healthy()
+
 }

--- a/src/main/scala/toguru/impl/ServerConnectivityMetrics.scala
+++ b/src/main/scala/toguru/impl/ServerConnectivityMetrics.scala
@@ -1,0 +1,59 @@
+package toguru.impl
+
+import com.codahale.metrics.{Gauge, JmxReporter, MetricRegistry}
+import org.komamitsu.failuredetector.PhiAccuralFailureDetector
+
+import scala.concurrent.duration.Duration
+
+trait ServerConnectivityMetrics {
+
+  def pollInterval: Duration
+
+  val RegistryDomain = "toguru-client"
+
+  val ConnectivityPhiGauge = "connectivity-phi-gauge"
+  val ConnectErrorCount    = "connect-error-count"
+  val FetchFailureCount    = "fetch-failure-count"
+
+  val metricsRegistry = new MetricRegistry()
+
+  val reporter = JmxReporter.forRegistry(metricsRegistry).inDomain(RegistryDomain).build()
+
+  reporter.start()
+
+  val connectivity = {
+    val builder = new PhiAccuralFailureDetector.Builder()
+
+    builder.setThreshold(16)
+    builder.setMaxSampleSize(200)
+    builder.setAcceptableHeartbeatPauseMillis(pollInterval.toMillis)
+    builder.setFirstHeartbeatEstimateMillis(pollInterval.toMillis)
+    builder.setMinStdDeviationMillis(100)
+
+    builder.build()
+  }
+
+  // this heartbeat call is needed to kickoff phi computation
+  connectivity.heartbeat()
+
+  metricsRegistry.register(ConnectivityPhiGauge, new Gauge[Double] { def getValue = connectivity.phi() })
+
+  val connectErrors = metricsRegistry.counter(ConnectErrorCount)
+
+  val fetchFailures = metricsRegistry.counter(FetchFailureCount)
+
+  def fetchSuccess() = connectivity.heartbeat()
+
+  def fetchFailed()  = fetchFailures.inc()
+
+  def connectError() = connectErrors.inc()
+
+  def healthy() = connectivity.isAvailable()
+
+  def deregister() = {
+    metricsRegistry.remove(ConnectivityPhiGauge)
+    metricsRegistry.remove(ConnectErrorCount)
+    metricsRegistry.remove(FetchFailureCount)
+    reporter.close()
+  }
+}

--- a/src/main/scala/toguru/test/TestActivations.scala
+++ b/src/main/scala/toguru/test/TestActivations.scala
@@ -9,6 +9,8 @@ object TestActivations {
 
   def apply(activations: (Toggle, Condition)*)(services: (Toggle, String)*) = new Activations.Provider() {
     override def apply() = new Impl(activations: _*)(services: _*)
+
+    override def healthy() = true
   }
 
   class Impl(activations: (Toggle, Condition)*)(services: (Toggle, String)*) extends Activations {

--- a/src/test/scala/toguru/api/ToguruClientSpec.scala
+++ b/src/test/scala/toguru/api/ToguruClientSpec.scala
@@ -1,0 +1,51 @@
+package toguru.api
+
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FeatureSpec, _}
+import toguru.api.Activations.Provider
+
+class ToguruClientSpec extends FeatureSpec with ShouldMatchers with MockitoSugar {
+
+  val mockClientInfo = ClientInfo()
+
+  val mockClientProvider: ClientInfo.Provider[String] = _ => mockClientInfo
+
+  def activationProvider(activations: Activations = DefaultActivations, health: Boolean): Activations.Provider =
+    new Provider {
+      def healthy() = health
+      def apply() = activations
+    }
+
+  def toguruClient(clientProvider: ClientInfo.Provider[String] = mockClientProvider, activations: Activations.Provider) =
+    new ToguruClient(clientProvider, activations)
+
+
+  feature("health check") {
+    scenario("activations provider is healthy") {
+      val client = toguruClient(activations = activationProvider(health = true))
+
+      client.healthy() shouldBe true
+    }
+
+    scenario("activations provider is unhealthy") {
+      val client = toguruClient(activations = activationProvider(health = false))
+
+      client.healthy() shouldBe false
+    }
+  }
+
+  feature("client info provider") {
+    scenario("client info requested") {
+      val myActivations = mock[Activations]
+      val myInfo = ClientInfo(userAgent = Some("me"))
+      val client = toguruClient(
+        clientProvider = _ => myInfo,
+        activations = activationProvider(health = true, activations = myActivations))
+
+      val toggling = client.apply("client")
+
+      toggling.activations shouldBe myActivations
+      toggling.client shouldBe myInfo
+    }
+  }
+}

--- a/src/test/scala/toguru/test/TestActivationsSpec.scala
+++ b/src/test/scala/toguru/test/TestActivationsSpec.scala
@@ -1,0 +1,44 @@
+package toguru.test
+
+import org.scalatest._
+import toguru.api._
+
+class TestActivationsSpec extends WordSpec with ShouldMatchers {
+
+  "healthy" should {
+    "always return true" in {
+      TestActivations()().healthy() shouldBe true
+    }
+  }
+
+  "activations" should {
+    "return the activations given in the constructor" in {
+      val toggle = Toggle("test-toggle")
+      val activationsProvider = TestActivations(toggle -> Condition.On)()
+      val activations = activationsProvider()
+
+      activations(toggle) shouldBe Condition.On
+    }
+
+    "return the default activations if no activation was given" in {
+      val toggle = Toggle("test-toggle", default = Condition.On)
+      val activationsProvider = TestActivations()()
+      val activations = activationsProvider()
+
+      activations(toggle) shouldBe Condition.On
+    }
+  }
+
+  "serviceFor" should {
+    "return the toggles as given in the test" in {
+      val toggle = Toggle("test-toggle")
+      val anotherToggle = Toggle("another-toggle")
+      val activations = TestActivations(toggle -> Condition.On, anotherToggle -> Condition.Off)(toggle -> "my-service")
+
+      val toggles = activations().togglesFor("my-service")
+
+      toggles.size shouldBe 1
+      toggles.get("test-toggle") shouldBe Some(Condition.On)
+    }
+  }
+}


### PR DESCRIPTION
- metrics about connectivity health and failures are now exposed via JMX
- connectivity health is computed with https://scholar.google.com/scholar?q=The+Phi+Accrual+failure+detector
   as provided by https://github.com/komamitsu/phi-accural-failure-detector
- adding missing shutdown hooks and deregister/close calls
- adding test for ToguruClient