### PR TITLE
Falling back to disabled toggle when client uuid is missing

### DIFF
--- a/src/main/scala/toguru/impl/Conditions.scala
+++ b/src/main/scala/toguru/impl/Conditions.scala
@@ -32,12 +32,14 @@ case class UuidDistributionCondition(ranges: Seq[Range], f: UUID => Int) extends
   ranges.foreach(r => if (r.head < 1 || r.last > 100) throw new IllegalArgumentException("Range should describe a range between 1 and 100 inclusive"))
 
   override def applies(clientInfo: ClientInfo): Boolean = {
-    // if no uuid is set use a random, but be aware that the feature is NOT stable for the client
-    val uuid = clientInfo.uuid.getOrElse(UUID.randomUUID())
-    val projected = f(uuid)
-    ranges.exists(range => {
-      range.contains(projected)
-    })
+    clientInfo.uuid match {
+      case Some(uuid) =>
+        val projected = f(uuid)
+        ranges.exists(range => {
+          range.contains(projected)
+        })
+      case None => false
+    }
   }
 }
 

--- a/src/test/scala/toguru/api/TogglingSpec.scala
+++ b/src/test/scala/toguru/api/TogglingSpec.scala
@@ -35,6 +35,16 @@ class TogglingSpec extends FeatureSpec with ShouldMatchers {
 
       toggle1.isOn shouldBe true
     }
+
+    scenario("toggle state falls back to false if client uuid is None") {
+      val toggle1 = Toggle("toggle-1", default = Condition.On)
+      val activation = new TestActivations.Impl(toggle1 -> Condition.UuidRange(1 to 100))()
+      val info = ClientInfo(uuid = None)
+
+      implicit val toggleInfo = TogglingInfo(info, activation)
+
+      toggle1.isOn shouldBe false
+    }
   }
 
   feature("Can build toggle strings") {

--- a/src/test/scala/toguru/impl/ConditionsSpec.scala
+++ b/src/test/scala/toguru/impl/ConditionsSpec.scala
@@ -1,9 +1,8 @@
 package toguru.impl
 
-import java.util.{Locale, UUID}
+import java.util.UUID
 
 import org.scalatest.{ShouldMatchers, WordSpec}
-import org.w3c.css.sac.AttributeCondition
 import toguru.api.ClientInfo
 
 class ConditionsSpec extends WordSpec with ShouldMatchers {
@@ -52,6 +51,16 @@ class ConditionsSpec extends WordSpec with ShouldMatchers {
     "apply to false if uuid is projected outside the given range" in {
       val clientInfo = ClientInfo(uuid = Some(uuidWithDefaultProjectionToFive))
       UuidDistributionCondition(10 to 11).applies(clientInfo) shouldBe false
+    }
+
+    "apply to false if uuid is none and rollout is 100%" in {
+      val clientInfo = ClientInfo(uuid = None)
+      UuidDistributionCondition(1 to 100).applies(clientInfo) shouldBe false
+    }
+
+    "apply to false if uuid is none and rollout is 1%" in {
+      val clientInfo = ClientInfo(uuid = None)
+      UuidDistributionCondition(1 to 1).applies(clientInfo) shouldBe false
     }
 
     "throw an exception if the range is not between 1 and 100" in {


### PR DESCRIPTION
Currently, the behaviour of a range condition is random picking a uuid when the client does not provide one. For a more stable behaviour, we propose to fallback to disabling the toggle in this case.
The consequence of this is that clients without uuids will not see the feature enabled unless it is forced on or uses an always on condition. Currently, rolling out a feature for clients without uuid will require additional code changes to be performed (i.e. changing the toggle default to always on). In the future, it should be possible to switch the toggle unconditionally on from the backend server, and make rolling out features to all clients simpler again.