### PR TITLE
Support for Scala 2.12 and Play 2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val root = project.in( file(".") ).enablePlugins(GitVersioning)
+lazy val root = project.in(file(".")).enablePlugins(GitVersioning)
 
 name := "toguru-scala-client"
 
@@ -11,18 +11,23 @@ bintrayOrganization := Some("autoscout24")
 
 crossScalaVersions in ThisBuild := Seq("2.12.1", "2.11.8")
 
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.12.2"
 
-scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation", "-feature", "-Xfatal-warnings",
-  "-Yno-adapted-args", "-Xmax-classfile-name", "130")
+scalacOptions in ThisBuild ++= Seq("-unchecked",
+                                   "-deprecation",
+                                   "-feature",
+                                   "-Xfatal-warnings",
+                                   "-Yno-adapted-args",
+                                   "-Xmax-classfile-name",
+                                   "130")
 
-val playVersion = "2.5.4"
+val playVersion = "2.6.1"
 
 resolvers += Resolver.jcenterRepo
 
 libraryDependencies in ThisBuild ++= Seq(
   "commons-io" % "commons-io" % "2.4",
-  "org.scalactic" %% "scalactic" % "2.2.5",
+  "org.scalactic" %% "scalactic" % "3.0.3",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
   "io.dropwizard.metrics" % "metrics-core" % "3.1.0",
@@ -30,18 +35,21 @@ libraryDependencies in ThisBuild ++= Seq(
   "com.typesafe.play" %% "play-json" % playVersion,
   "com.typesafe.play" %% "play" % playVersion % "optional",
   "com.typesafe.play" %% "play-test" % playVersion % "optional",
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "com.hootsuite" %% "scala-circuit-breaker" % "1.0.0",
+  "org.scalatest" %% "scalatest" % "3.0.3" % "test",
+  "com.hootsuite" %% "scala-circuit-breaker" % "1.0.1",
   "org.mockito" % "mockito-core" % "2.0.8-beta" % "test",
-  "org.http4s" %% "http4s-dsl" % "0.14.8a" % "test",
-  "org.http4s" %% "http4s-blaze-server" % "0.14.8a" % "test"
+  "org.http4s" %% "http4s-dsl" % "0.17.0-M3" % "test",
+  "org.http4s" %% "http4s-blaze-server" % "0.17.0-M3" % "test"
 )
 
-ScoverageSbtPlugin.ScoverageKeys.coverageMinimum := 80
+scoverage.ScoverageKeys.coverageMinimum := 80
 
-ScoverageSbtPlugin.ScoverageKeys.coverageFailOnMinimum := true
+scoverage.ScoverageKeys.coverageFailOnMinimum := true
 
 resolvers in ThisBuild ++= Seq(
   Classpaths.sbtPluginReleases,
-  "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
+  "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
+  Resolver.url("scoverage-bintray",
+               url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(
+    Resolver.ivyStylePatterns)
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.0")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+addSbtPlugin("org.scoverage" %% "sbt-coveralls" % "1.1.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 

--- a/src/main/scala/toguru/play/package.scala
+++ b/src/main/scala/toguru/play/package.scala
@@ -3,7 +3,7 @@ package toguru
 import _root_.play.api.mvc._
 import toguru.api.{Activations, ClientInfo, Toggling, ToguruClient}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 package object play {
 
@@ -24,14 +24,20 @@ package object play {
     *
     * @param toguruClient the toguru client to use.
     */
-  class TogglingRefiner(toguruClient: PlayToguruClient) extends ActionRefiner[Request, ToggledRequest] {
+  class TogglingRefiner(toguruClient: PlayToguruClient)(
+      implicit val executionContext: ExecutionContext)
+      extends ActionRefiner[Request, ToggledRequest] {
     def refine[A](request: Request[A]) = Future.successful {
-      Right(new ToggledRequest[A](toguruClient.clientProvider(request), toguruClient.activationsProvider(), request))
+      Right(
+        new ToggledRequest[A](toguruClient.clientProvider(request),
+                              toguruClient.activationsProvider(),
+                              request))
     }
   }
 
-  class ToggledRequest[A](
-             val client: ClientInfo,
-             val activations: Activations,
-             request : Request[A]) extends WrappedRequest[A](request) with Toggling
+  class ToggledRequest[A](val client: ClientInfo,
+                          val activations: Activations,
+                          request: Request[A])
+      extends WrappedRequest[A](request)
+      with Toggling
 }

--- a/src/test/scala/toguru/api/ActivationsSpec.scala
+++ b/src/test/scala/toguru/api/ActivationsSpec.scala
@@ -1,16 +1,17 @@
 package toguru.api
 
-import org.scalatest.mock.MockitoSugar
-import org.scalatest.{FeatureSpec, ShouldMatchers}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FeatureSpec, MustMatchers}
 import toguru.impl.RemoteActivationsProvider
 
-class ActivationsSpec extends FeatureSpec with ShouldMatchers with MockitoSugar {
+class ActivationsSpec extends FeatureSpec with MustMatchers with MockitoSugar {
 
   feature("Remote activations provider") {
     scenario("can be created") {
-      val provider = Activations.fromEndpoint("http://localhost:9000/togglestates")
+      val provider =
+        Activations.fromEndpoint("http://localhost:9000/togglestates")
 
-      provider shouldBe a[RemoteActivationsProvider]
+      provider mustBe a[RemoteActivationsProvider]
       provider.asInstanceOf[RemoteActivationsProvider].close()
     }
   }
@@ -20,15 +21,15 @@ class ActivationsSpec extends FeatureSpec with ShouldMatchers with MockitoSugar 
       val condition = mock[Condition]
       val toggle = Toggle("toggle-1", condition)
 
-      DefaultActivations.apply(toggle) shouldBe condition
+      DefaultActivations.apply(toggle) mustBe condition
     }
 
     scenario("return empty service toggles") {
-      DefaultActivations.togglesFor("my-service") shouldBe Map.empty
+      DefaultActivations.togglesFor("my-service") mustBe Map.empty
     }
 
     scenario("return None for sequenceNo") {
-      DefaultActivations.stateSequenceNo shouldBe None
+      DefaultActivations.stateSequenceNo mustBe None
     }
   }
 }

--- a/src/test/scala/toguru/api/ConditionSpec.scala
+++ b/src/test/scala/toguru/api/ConditionSpec.scala
@@ -2,29 +2,30 @@ package toguru.api
 
 import org.scalatest.{FeatureSpec, _}
 
-class ConditionSpec extends FeatureSpec with ShouldMatchers {
+class ConditionSpec extends FeatureSpec with MustMatchers {
 
   feature("Off Condition") {
     scenario("can be created by API") {
-      Condition.Off shouldBe a[Condition]
+      Condition.Off mustBe a[Condition]
     }
   }
 
   feature("On Condition") {
     scenario("can be created") {
-      Condition.On shouldBe a[Condition]
+      Condition.On mustBe a[Condition]
     }
   }
 
   feature("Rollout Range Condition") {
     scenario("can be created") {
-      Condition.UuidRange(1 to 20) shouldBe a[Condition]
+      Condition.UuidRange(1 to 20) mustBe a[Condition]
     }
   }
 
   feature("Attribute Condition") {
     scenario("can be created") {
-      Condition.Attribute("myAttribute", "one", "two", "three") shouldBe a[Condition]
+      Condition.Attribute("myAttribute", "one", "two", "three") mustBe a[
+        Condition]
     }
   }
 
@@ -33,15 +34,15 @@ class ConditionSpec extends FeatureSpec with ShouldMatchers {
       import Condition._
       Condition(
         UuidRange(1 to 20),
-        Attribute("myAttribute", "one", "two", "three")) shouldBe a[Condition]
+        Attribute("myAttribute", "one", "two", "three")) mustBe a[Condition]
     }
 
     scenario("when created from one condition yields the given condition") {
-      Condition(Condition.Off) shouldBe Condition.Off
+      Condition(Condition.Off) mustBe Condition.Off
     }
 
     scenario("when created from empty conditions yields Condition 'On'") {
-      Condition() shouldBe Condition.On
+      Condition() mustBe Condition.On
     }
   }
 }

--- a/src/test/scala/toguru/api/ToggleSpec.scala
+++ b/src/test/scala/toguru/api/ToggleSpec.scala
@@ -1,9 +1,9 @@
 package toguru.api
 
-import org.scalatest.{FeatureSpec, ShouldMatchers}
+import org.scalatest.{FeatureSpec, MustMatchers}
 import toguru.test.TestActivations
 
-class ToggleSpec extends FeatureSpec with ShouldMatchers {
+class ToggleSpec extends FeatureSpec with MustMatchers {
 
   val emptyToggleInfo = TogglingInfo(ClientInfo(), new TestActivations.Impl()())
 
@@ -12,16 +12,16 @@ class ToggleSpec extends FeatureSpec with ShouldMatchers {
       val toggle1 = Toggle("toggle-1")
       implicit val toggleInfo = emptyToggleInfo
 
-      toggle1.isOn shouldBe false
-      toggle1.isOff shouldBe true
+      toggle1.isOn mustBe false
+      toggle1.isOff mustBe true
     }
 
     scenario("default condition is respected") {
       val toggle1 = Toggle("toggle-1", default = Condition.On)
       implicit val toggleInfo = emptyToggleInfo
 
-      toggle1.isOn shouldBe true
-      toggle1.isOff shouldBe false
+      toggle1.isOn mustBe true
+      toggle1.isOff mustBe false
     }
   }
 }

--- a/src/test/scala/toguru/api/TogglingSpec.scala
+++ b/src/test/scala/toguru/api/TogglingSpec.scala
@@ -5,7 +5,7 @@ import toguru.helpers.ClientInfoHelper
 import toguru.helpers.ClientInfoHelper._
 import toguru.test.TestActivations
 
-class TogglingSpec extends FeatureSpec with ShouldMatchers {
+class TogglingSpec extends FeatureSpec with MustMatchers {
 
   feature("Can change toggle state") {
     scenario("toggle state in toggle info is applied") {
@@ -14,7 +14,7 @@ class TogglingSpec extends FeatureSpec with ShouldMatchers {
 
       implicit val info = TogglingInfo(ClientInfo(), activation)
 
-      toggle1.isOn shouldBe true
+      toggle1.isOn mustBe true
     }
 
     scenario("default toggle state is applied") {
@@ -23,58 +23,68 @@ class TogglingSpec extends FeatureSpec with ShouldMatchers {
 
       implicit val info = TogglingInfo(ClientInfo(), activation)
 
-      toggle1.isOn shouldBe true
+      toggle1.isOn mustBe true
     }
 
     scenario("toggle state can be forced by client info") {
       val toggle1 = Toggle("toggle-1", default = Condition.Off)
       val activation = new TestActivations.Impl(toggle1 -> Condition.Off)()
-      val info = ClientInfo(forcedToggle = ClientInfoHelper.forceToggleTo("toggle-1", enabled = true))
+      val info = ClientInfo(
+        forcedToggle =
+          ClientInfoHelper.forceToggleTo("toggle-1", enabled = true))
 
       implicit val toggleInfo = TogglingInfo(info, activation)
 
-      toggle1.isOn shouldBe true
+      toggle1.isOn mustBe true
     }
 
     scenario("toggle state falls back to false if client uuid is None") {
       val toggle1 = Toggle("toggle-1", default = Condition.On)
-      val activation = new TestActivations.Impl(toggle1 -> Condition.UuidRange(1 to 100))()
+      val activation =
+        new TestActivations.Impl(toggle1 -> Condition.UuidRange(1 to 100))()
       val info = ClientInfo(uuid = None)
 
       implicit val toggleInfo = TogglingInfo(info, activation)
 
-      toggle1.isOn shouldBe false
+      toggle1.isOn mustBe false
     }
   }
 
   feature("Can build toggle strings") {
     import toguru.implicits.toggle._
 
-    scenario("produces 'on' when toggle state is 'off' but the client overrides it to be 'on'") {
+    scenario(
+      "produces 'on' when toggle state is 'off' but the client overrides it to be 'on'") {
       val toggle = Toggle("feature1")
-      val activations = TestActivations(toggle -> Condition.Off)(toggle -> "service1")()
-      val clientInfo = ClientInfo(None, forceToggleTo("feature1", enabled = true))
+      val activations =
+        TestActivations(toggle -> Condition.Off)(toggle -> "service1")()
+      val clientInfo =
+        ClientInfo(None, forceToggleTo("feature1", enabled = true))
       implicit val toggleInfo = TogglingInfo(clientInfo, activations)
 
-      toggleInfo().buildString should be("feature1=true")
+      toggleInfo().buildString mustBe ("feature1=true")
     }
 
-    scenario("produces 'off' when toggle state is 'on' but the client overrides it to be 'off'") {
+    scenario(
+      "produces 'off' when toggle state is 'on' but the client overrides it to be 'off'") {
       val toggle = Toggle("feature1")
-      val activations = TestActivations(toggle -> Condition.On)(toggle -> "service1")()
-      implicit val clientInfo: ClientInfo = ClientInfo(None, forceToggleTo("feature1", enabled = false))
+      val activations =
+        TestActivations(toggle -> Condition.On)(toggle -> "service1")()
+      implicit val clientInfo: ClientInfo =
+        ClientInfo(None, forceToggleTo("feature1", enabled = false))
       implicit val toggleInfo = TogglingInfo(clientInfo, activations)
 
-      toggleInfo().buildString should be("feature1=false")
+      toggleInfo().buildString mustBe ("feature1=false")
     }
 
     scenario("produces 'on' when toggle state is 'on'") {
       val toggle = Toggle("feature1")
-      val activations = TestActivations(toggle -> Condition.On)(toggle -> "service1")()
+      val activations =
+        TestActivations(toggle -> Condition.On)(toggle -> "service1")()
       implicit val clientInfo: ClientInfo = ClientInfo()
       implicit val toggleInfo = TogglingInfo(clientInfo, activations)
 
-      toggleInfo().buildString should be("feature1=true")
+      toggleInfo().buildString mustBe ("feature1=true")
     }
 
   }

--- a/src/test/scala/toguru/api/ToguruClientSpec.scala
+++ b/src/test/scala/toguru/api/ToguruClientSpec.scala
@@ -1,36 +1,39 @@
 package toguru.api
 
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FeatureSpec, _}
 import toguru.api.Activations.Provider
 
-class ToguruClientSpec extends FeatureSpec with ShouldMatchers with MockitoSugar {
+class ToguruClientSpec extends FeatureSpec with MustMatchers with MockitoSugar {
 
   val mockClientInfo = ClientInfo()
 
   val mockClientProvider: ClientInfo.Provider[String] = _ => mockClientInfo
 
-  def activationProvider(activations: Activations = DefaultActivations, health: Boolean): Activations.Provider =
+  def activationProvider(activations: Activations = DefaultActivations,
+                         health: Boolean): Activations.Provider =
     new Provider {
       def healthy() = health
       def apply() = activations
     }
 
-  def toguruClient(clientProvider: ClientInfo.Provider[String] = mockClientProvider, activations: Activations.Provider) =
+  def toguruClient(clientProvider: ClientInfo.Provider[String] =
+                     mockClientProvider,
+                   activations: Activations.Provider) =
     new ToguruClient(clientProvider, activations)
-
 
   feature("health check") {
     scenario("activations provider is healthy") {
       val client = toguruClient(activations = activationProvider(health = true))
 
-      client.healthy() shouldBe true
+      client.healthy() mustBe true
     }
 
     scenario("activations provider is unhealthy") {
-      val client = toguruClient(activations = activationProvider(health = false))
+      val client =
+        toguruClient(activations = activationProvider(health = false))
 
-      client.healthy() shouldBe false
+      client.healthy() mustBe false
     }
   }
 
@@ -40,12 +43,13 @@ class ToguruClientSpec extends FeatureSpec with ShouldMatchers with MockitoSugar
       val myInfo: ClientInfo = ClientInfo().withAttribute("user", "me")
       val client = toguruClient(
         clientProvider = _ => myInfo,
-        activations = activationProvider(health = true, activations = myActivations))
+        activations =
+          activationProvider(health = true, activations = myActivations))
 
       val toggling = client.apply("client")
 
-      toggling.activations shouldBe myActivations
-      toggling.client shouldBe myInfo
+      toggling.activations mustBe myActivations
+      toggling.client mustBe myInfo
     }
   }
 }

--- a/src/test/scala/toguru/impl/ConditionsSpec.scala
+++ b/src/test/scala/toguru/impl/ConditionsSpec.scala
@@ -2,65 +2,69 @@ package toguru.impl
 
 import java.util.UUID
 
-import org.scalatest.{ShouldMatchers, WordSpec}
+import org.scalatest.{MustMatchers, WordSpec}
 import toguru.api.ClientInfo
 
-class ConditionsSpec extends WordSpec with ShouldMatchers {
+class ConditionsSpec extends WordSpec with MustMatchers {
 
   "Attribute conditions" should {
     "apply correctly to de-DE culture" in {
       val clientInfo = ClientInfo(attributes = Map("culture" -> "de-DE"))
 
-      Attribute("culture", Seq("de-DE")).applies(clientInfo) shouldBe true
+      Attribute("culture", Seq("de-DE")).applies(clientInfo) mustBe true
     }
 
     "apply if one value matches" in {
       val clientInfo = ClientInfo(attributes = Map("culture" -> "de-DE"))
 
-      Attribute("culture", Seq("de-DE", "de-AT")).applies(clientInfo) shouldBe true
+      Attribute("culture", Seq("de-DE", "de-AT"))
+        .applies(clientInfo) mustBe true
     }
   }
 
   "All conditions" should {
-    val myAllCondition = All(Set(Attribute("one", Seq("one")), Attribute("two", Seq("two"))))
+    val myAllCondition =
+      All(Set(Attribute("one", Seq("one")), Attribute("two", Seq("two"))))
 
     "return true if no condition is given" in {
       val clientInfo = ClientInfo()
-      All(Set.empty).applies(clientInfo) shouldBe true
+      All(Set.empty).applies(clientInfo) mustBe true
     }
 
     "Evaluate to true if all conditions are met" in {
-      val clientInfo = ClientInfo(attributes = Map("one" -> "one", "two" -> "two"))
-      myAllCondition.applies(clientInfo) shouldBe true
+      val clientInfo =
+        ClientInfo(attributes = Map("one" -> "one", "two" -> "two"))
+      myAllCondition.applies(clientInfo) mustBe true
     }
 
     "Evaluate to false if one condition is unmet" in {
       val clientInfo = ClientInfo(attributes = Map("one" -> "one"))
-      myAllCondition.applies(clientInfo) shouldBe false
+      myAllCondition.applies(clientInfo) mustBe false
     }
   }
 
   "Uuid distribution conditions" should {
-    val uuidWithDefaultProjectionToFive = UUID.fromString("56ed135b-a474-41d4-bde1-bc5e1e8bf910")
+    val uuidWithDefaultProjectionToFive =
+      UUID.fromString("56ed135b-a474-41d4-bde1-bc5e1e8bf910")
 
     "apply to true if uuid is projected into the given range" in {
       val clientInfo = ClientInfo(uuid = Some(uuidWithDefaultProjectionToFive))
-      UuidDistributionCondition(3 to 5).applies(clientInfo) shouldBe true
+      UuidDistributionCondition(3 to 5).applies(clientInfo) mustBe true
     }
 
     "apply to false if uuid is projected outside the given range" in {
       val clientInfo = ClientInfo(uuid = Some(uuidWithDefaultProjectionToFive))
-      UuidDistributionCondition(10 to 11).applies(clientInfo) shouldBe false
+      UuidDistributionCondition(10 to 11).applies(clientInfo) mustBe false
     }
 
     "apply to false if uuid is none and rollout is 100%" in {
       val clientInfo = ClientInfo(uuid = None)
-      UuidDistributionCondition(1 to 100).applies(clientInfo) shouldBe false
+      UuidDistributionCondition(1 to 100).applies(clientInfo) mustBe false
     }
 
     "apply to false if uuid is none and rollout is 1%" in {
       val clientInfo = ClientInfo(uuid = None)
-      UuidDistributionCondition(1 to 1).applies(clientInfo) shouldBe false
+      UuidDistributionCondition(1 to 1).applies(clientInfo) mustBe false
     }
 
     "throw an exception if the range is not between 1 and 100" in {
@@ -75,8 +79,8 @@ class ConditionsSpec extends WordSpec with ShouldMatchers {
 
     s"project random uuid ($uuid) between 1 and 100" in {
       val projected = UuidDistributionCondition.defaultUuidToIntProjection(uuid)
-      projected shouldBe >(0)
-      projected shouldBe <=(100)
+      projected mustBe >(0)
+      projected mustBe <=(100)
     }
   }
 }

--- a/src/test/scala/toguru/impl/ToggleStateSpec.scala
+++ b/src/test/scala/toguru/impl/ToggleStateSpec.scala
@@ -1,81 +1,102 @@
 package toguru.impl
 
-import org.scalatest.mock.MockitoSugar
-import org.scalatest.{ShouldMatchers, WordSpec}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{MustMatchers, WordSpec}
 import toguru.api.{Condition, Toggle}
 import toguru.implicits.toggle
 
-class ToggleStateSpec extends WordSpec with ShouldMatchers with MockitoSugar {
+class ToggleStateSpec extends WordSpec with MustMatchers with MockitoSugar {
 
-  def activation(rollout: Option[Rollout] = None, attrs: Map[String, Seq[String]] = Map.empty) =
+  def activation(rollout: Option[Rollout] = None,
+                 attrs: Map[String, Seq[String]] = Map.empty) =
     Seq(ToggleActivation(rollout, attrs))
 
   def rollout(r: Int) = Some(Rollout(r))
 
   val toggles = List(
-    ToggleState("toggle1", Map("services" -> "toguru"), activation(rollout(30))),
-    ToggleState("toggle-2", Map.empty[String, String], activation(rollout(100))),
-    ToggleState("toggle-4", Map.empty[String, String], activation(attrs = Map("culture" -> Seq("DE", "de-DE"), "version" -> Seq("1", "2")))),
-    ToggleState("toggle-5", Map.empty[String, String], activation(rollout(30), attrs = Map("culture" -> Seq("DE", "de-DE"), "version" -> Seq("1", "2")))))
-
+    ToggleState("toggle1",
+                Map("services" -> "toguru"),
+                activation(rollout(30))),
+    ToggleState("toggle-2",
+                Map.empty[String, String],
+                activation(rollout(100))),
+    ToggleState("toggle-4",
+                Map.empty[String, String],
+                activation(
+                  attrs = Map("culture" -> Seq("DE", "de-DE"),
+                              "version" -> Seq("1", "2")))),
+    ToggleState("toggle-5",
+                Map.empty[String, String],
+                activation(rollout(30),
+                           attrs = Map("culture" -> Seq("DE", "de-DE"),
+                                       "version" -> Seq("1", "2"))))
+  )
 
   "ToggleState.apply" should {
 
     "transform activations into conditions" in {
       val condition = toggles(0).condition
 
-      condition shouldBe a[UuidDistributionCondition]
+      condition mustBe a[UuidDistributionCondition]
 
       val uuidCondition = condition.asInstanceOf[UuidDistributionCondition]
 
-      uuidCondition.ranges shouldBe List(1 to 30)
+      uuidCondition.ranges mustBe List(1 to 30)
     }
 
     "Adds AlwayOffCondition if only attribute contitions are given" in {
       val condition = toggles(2).condition
 
-      condition shouldBe All(Set(AlwaysOffCondition, Attribute("culture", Seq("DE", "de-DE")), Attribute("version", Seq("1", "2"))))
+      condition mustBe All(
+        Set(AlwaysOffCondition,
+            Attribute("culture", Seq("DE", "de-DE")),
+            Attribute("version", Seq("1", "2"))))
     }
 
     "transform combinations of rollout and attributes to conditions" in {
       val condition = toggles(3).condition
 
-      condition shouldBe All(Set(
-        UuidDistributionCondition(List(1 to 30), UuidDistributionCondition.defaultUuidToIntProjection),
-        Attribute("culture", Seq("DE", "de-DE")),
-        Attribute("version", Seq("1", "2"))))
+      condition mustBe All(
+        Set(
+          UuidDistributionCondition(
+            List(1 to 30),
+            UuidDistributionCondition.defaultUuidToIntProjection),
+          Attribute("culture", Seq("DE", "de-DE")),
+          Attribute("version", Seq("1", "2"))
+        ))
     }
   }
 
   "ToggleState.activations" should {
 
-    val activations = new ToggleStateActivations(ToggleStates(Some(10), toggles))
+    val activations =
+      new ToggleStateActivations(ToggleStates(Some(10), toggles))
 
     "return toggle conditions for services" in {
       val toguruToggles = activations.togglesFor("toguru")
 
-      toguruToggles should have size 1
-      toguruToggles.keySet shouldBe Set("toggle1")
+      toguruToggles must have size 1
+      toguruToggles.keySet mustBe Set("toggle1")
 
       val condition = toguruToggles("toggle1")
 
-      condition shouldBe a[UuidDistributionCondition]
+      condition mustBe a[UuidDistributionCondition]
 
       val uuidCondition = condition.asInstanceOf[UuidDistributionCondition]
 
-      uuidCondition.ranges shouldBe List(1 to 30)
+      uuidCondition.ranges mustBe List(1 to 30)
     }
 
     "return toggle default conditions if toggle is unknown" in {
       val condition = mock[Condition]
       val toggle = Toggle("toggle-3", condition)
 
-      activations.apply(toggle) shouldBe condition
+      activations.apply(toggle) mustBe condition
     }
 
     "apply should return togglestates" in {
 
-      activations() shouldBe toggles
+      activations() mustBe toggles
     }
   }
 

--- a/src/test/scala/toguru/impl/TogglesStringSpec.scala
+++ b/src/test/scala/toguru/impl/TogglesStringSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.OptionValues._
 import org.scalatest._
 import toguru.api._
 
-class TogglesStringSpec extends WordSpec with ShouldMatchers {
+class TogglesStringSpec extends WordSpec with MustMatchers {
 
   "Parsing of forced features string" should {
 
@@ -12,25 +12,26 @@ class TogglesStringSpec extends WordSpec with ShouldMatchers {
     val forcedToggles = TogglesString.parse(forcedTogglesString)
 
     "Existing features are correctly forced" in {
-      forcedToggles("feature1").value shouldBe true
-      forcedToggles("feature2").value shouldBe false
-      forcedToggles("feature3").value shouldBe true
+      forcedToggles("feature1").value mustBe true
+      forcedToggles("feature2").value mustBe false
+      forcedToggles("feature3").value mustBe true
     }
 
     "Non existant forced features return None" in {
-      forcedToggles("i do not exist") shouldBe None
+      forcedToggles("i do not exist") mustBe None
     }
 
     "Feature forcing is case insensitive" in {
-      forcedToggles("FEATURE1").value shouldBe true
+      forcedToggles("FEATURE1").value mustBe true
     }
 
     "Illegal feature spec returns None for feature specified wrongly" in {
-      val forcedFeaturesString = "feature1=thisiswrong|feature2=false|feature3=true"
+      val forcedFeaturesString =
+        "feature1=thisiswrong|feature2=false|feature3=true"
       val forcedFeatures = TogglesString.parse(forcedFeaturesString)
 
-      forcedFeatures("feature1") shouldBe None
-      forcedFeatures("feature3").value shouldBe true
+      forcedFeatures("feature1") mustBe None
+      forcedFeatures("feature3").value mustBe true
     }
   }
 
@@ -38,29 +39,28 @@ class TogglesStringSpec extends WordSpec with ShouldMatchers {
 
     "returns empty string when there are no features" in {
       implicit val clientInfo: ClientInfo = ClientInfo()
-      TogglesString.build(Map.empty) shouldBe ""
+      TogglesString.build(Map.empty) mustBe ""
     }
 
     "returns the correct feature when it is enforced to be true" in {
       implicit val clientInfo: ClientInfo = ClientInfo()
       val toggleStates = Map("feature1" -> true)
 
-      TogglesString.build(toggleStates) shouldBe "feature1=true"
+      TogglesString.build(toggleStates) mustBe "feature1=true"
     }
 
     "returns the disabled feature when it is enforced to be false" in {
       implicit val clientInfo: ClientInfo = ClientInfo()
       val toggleStates = Map("feature1" -> false)
 
-      TogglesString.build(toggleStates) shouldBe "feature1=false"
+      TogglesString.build(toggleStates) mustBe "feature1=false"
     }
-
 
     "returns multiple features separated by a pipe" in {
       implicit val clientInfo: ClientInfo = ClientInfo()
       val toggleStates = Map("feature1" -> false, "feature2" -> true)
 
-      TogglesString.build(toggleStates) shouldBe "feature1=false|feature2=true"
+      TogglesString.build(toggleStates) mustBe "feature1=false|feature2=true"
     }
   }
 

--- a/src/test/scala/toguru/impl/UuidDistributionConditionSpec.scala
+++ b/src/test/scala/toguru/impl/UuidDistributionConditionSpec.scala
@@ -3,33 +3,35 @@ package toguru.impl
 import java.util.UUID
 
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{ShouldMatchers, WordSpec}
+import org.scalatest.{MustMatchers, WordSpec}
 import toguru.api.ClientInfo
 
-class UuidDistributionConditionSpec extends WordSpec with ShouldMatchers with TableDrivenPropertyChecks {
+class UuidDistributionConditionSpec
+    extends WordSpec
+    with MustMatchers
+    with TableDrivenPropertyChecks {
 
   "Invalid ranges" should {
     "Lower boundary is too low" in {
 
       intercept[IllegalArgumentException] {
         UuidDistributionCondition.apply(0 to 10)
-      }.getMessage shouldBe "Range should describe a range between 1 and 100 inclusive"
+      }.getMessage mustBe "Range should describe a range between 1 and 100 inclusive"
     }
 
     "Upper boundary is too high" in {
       intercept[IllegalArgumentException] {
         UuidDistributionCondition.apply(90 to 101)
-      }.getMessage shouldBe "Range should describe a range between 1 and 100 inclusive"
+      }.getMessage mustBe "Range should describe a range between 1 and 100 inclusive"
     }
   }
 
   "Valid UUIDs" should {
     "be projected within max range" in {
-      1 to 1000 foreach {
-        _ =>
-          val uuid = UUID.randomUUID()
-          val info = ClientInfo(uuid = Some(uuid))
-          UuidDistributionCondition.apply(1 to 100).applies(info) shouldBe true
+      1 to 1000 foreach { _ =>
+        val uuid = UUID.randomUUID()
+        val info = ClientInfo(uuid = Some(uuid))
+        UuidDistributionCondition.apply(1 to 100).applies(info) mustBe true
       }
     }
   }
@@ -64,7 +66,7 @@ class UuidDistributionConditionSpec extends WordSpec with ShouldMatchers with Ta
       val projection = UuidDistributionCondition.defaultUuidToIntProjection
 
       forAll(uuidMappings) { (uuid: String, bucket: Int) =>
-        projection(UUID.fromString(uuid)) shouldBe bucket
+        projection(UUID.fromString(uuid)) mustBe bucket
       }
     }
   }

--- a/src/test/scala/toguru/play/PlaySupportSpec.scala
+++ b/src/test/scala/toguru/play/PlaySupportSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import javax.inject.Inject
 
 import akka.util.Timeout
-import org.scalatest.{ShouldMatchers, WordSpec}
+import org.scalatest.{MustMatchers, WordSpec}
 import play.api.http.{HeaderNames, HttpVerbs}
 import play.api.mvc._
 import play.api.test.{FakeHeaders, FakeRequest, Helpers}
@@ -16,7 +16,7 @@ import toguru.test.TestActivations
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 
-class PlaySupportSpec extends WordSpec with ShouldMatchers {
+class PlaySupportSpec extends WordSpec with MustMatchers {
 
   val UserAgent = HeaderNames.USER_AGENT
 
@@ -24,54 +24,66 @@ class PlaySupportSpec extends WordSpec with ShouldMatchers {
 
   val client: PlayClientProvider = { implicit request =>
     import PlaySupport._
-    ClientInfo(uuidFromCookieValue("myVisitor"), forcedToggle).withAttribute(fromCookie("culture")).withAttribute(fromHeader(UserAgent))
+    ClientInfo(uuidFromCookieValue("myVisitor"), forcedToggle)
+      .withAttribute(fromCookie("culture"))
+      .withAttribute(fromHeader(UserAgent))
   }
 
   // you will write such a class in your play app to automatically convert from Play's RequestHeader to ClientInfo
-  abstract class ToggledController(toguru: PlayToguruClient) extends Controller {
-    val ToggledAction = PlaySupport.ToggledAction(toguru)
+  abstract class ToggledController(toguru: PlayToguruClient,
+                                   cc: ControllerComponents)
+      extends AbstractController(cc) {
+    val ToggledAction =
+      PlaySupport.ToggledAction(toguru, cc.parsers.defaultBodyParser)
   }
 
-  class MyController @Inject()(toguru: PlayToguruClient) extends ToggledController(toguru) {
+  class MyController @Inject()(toguru: PlayToguruClient,
+                               cc: ControllerComponents)
+      extends ToggledController(toguru, cc) {
 
     def myAction = ToggledAction { implicit request =>
-      if(toggle.isOn)
+      if (toggle.isOn)
         Ok("Toggle is on")
       else
         Ok("Toggle is off")
     }
   }
 
-  class MyRequest[A](toguru: PlayToguruClient, request : Request[A]) extends WrappedRequest[A](request) with Toggling {
+  class MyRequest[A](toguru: PlayToguruClient, request: Request[A])
+      extends WrappedRequest[A](request)
+      with Toggling {
     override val client = toguru.clientProvider(request)
 
     override val activations = toguru.activationsProvider()
   }
 
-  class MyControllerWithOwnTogglingInfo @Inject()(toguru: PlayToguruClient) extends Controller {
+  class MyControllerWithOwnTogglingInfo @Inject()(toguru: PlayToguruClient,
+                                                  cc: ControllerComponents)
+      extends AbstractController(cc) {
 
     def myAction = Action { request =>
       implicit val toggling = toguru(request)
 
-      if(toggle.isOn)
+      if (toggle.isOn)
         Ok("Toggle is on")
       else
         Ok("Toggle is off")
     }
   }
 
-  def createToggledController(provider: Activations.Provider = TestActivations()()) = {
+  def createToggledController(
+      provider: Activations.Provider = TestActivations()()) = {
 
     val toguruClient = PlaySupport.testToguruClient(client, provider)
 
-
-    new ToggledController(toguruClient) { }
+    new ToggledController(toguruClient, Helpers.stubControllerComponents()) {}
   }
 
   "toguruClient method" should {
     "create a PlayToguruClient" in {
-      val client = PlaySupport.toguruClient(_ => ClientInfo(), "http://localhost:9001")
-      client shouldBe a[PlayToguruClient]
+      val client =
+        PlaySupport.toguruClient(_ => ClientInfo(), "http://localhost:9001")
+      client mustBe a[PlayToguruClient]
 
       client.activationsProvider.asInstanceOf[RemoteActivationsProvider].close()
     }
@@ -80,96 +92,138 @@ class PlaySupportSpec extends WordSpec with ShouldMatchers {
   "ToggledAction helper" should {
     "provide request with toggling information" in {
       implicit val timeout = Timeout(2.seconds)
-      val toguru = PlaySupport.testToguruClient(client, TestActivations(toggle -> Condition.On)())
-      val controller = new MyController(toguru)
+      val toguru =
+        PlaySupport.testToguruClient(client,
+                                     TestActivations(toggle -> Condition.On)())
+      val controller =
+        new MyController(toguru, Helpers.stubControllerComponents())
 
       val request = FakeRequest(HttpVerbs.GET, "/")
 
       val response = controller.myAction(request)
 
-      Helpers.contentAsString(response) shouldBe "Toggle is on"
+      Helpers.contentAsString(response) mustBe "Toggle is on"
     }
   }
 
   "Direct toggling info" should {
     "provide toggling information" in {
       implicit val timeout = Timeout(2.seconds)
-      val toguru = PlaySupport.testToguruClient(client, TestActivations(toggle -> Condition.On)())
-      val controller = new MyControllerWithOwnTogglingInfo(toguru)
+      val toguru =
+        PlaySupport.testToguruClient(client,
+                                     TestActivations(toggle -> Condition.On)())
+      val controller =
+        new MyControllerWithOwnTogglingInfo(toguru,
+                                            Helpers.stubControllerComponents())
 
       val request = FakeRequest(HttpVerbs.GET, "/")
 
       val response = controller.myAction(request)
 
-      Helpers.contentAsString(response) shouldBe "Toggle is on"
+      Helpers.contentAsString(response) mustBe "Toggle is on"
     }
   }
 
+  val fakeHeaders = FakeHeaders(
+    Seq(
+      UserAgent -> "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",
+      "X-toguru" -> "feature1-Forced-By-Header=true|feature2-Forced-By-Header=true",
+      HeaderNames.COOKIE ->
+        Cookies.encodeCookieHeader(Seq(
+          Cookie("culture", "de-DE"),
+          Cookie("myVisitor", "a5f409eb-2fdd-4499-b65b-b22bd7e51aa2"),
+          Cookie(
+            "toguru",
+            "feature1-Forced-By-Cookie=true|feature2-Forced-By-Cookie=true")
+        ))
+    ))
 
-  val fakeHeaders = FakeHeaders(Seq(
-    UserAgent -> "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",
-    "X-toguru" -> "feature1-Forced-By-Header=true|feature2-Forced-By-Header=true",
-    HeaderNames.COOKIE ->
-      Cookies.encodeCookieHeader(Seq(
-        Cookie("culture", "de-DE"),
-        Cookie("myVisitor", "a5f409eb-2fdd-4499-b65b-b22bd7e51aa2"),
-        Cookie("toguru", "feature1-Forced-By-Cookie=true|feature2-Forced-By-Cookie=true")
-      ))
-  ))
-
-  val request = FakeRequest.apply("GET", "http://priceestimation.autoscout24.de?toguru=feature-forced-by-query-param%3Dtrue", fakeHeaders, "body")
-  val requestWithToggleIdUpppercased = FakeRequest.apply("GET", "http://priceestimation.autoscout24.de?toguru=feature-FORCED-by-query-param%3Dtrue", fakeHeaders, "body")
-  val requestWithTwoTogglesInQueryString = FakeRequest.apply("GET",
-    "http://priceestimation.autoscout24.de?toguru=feature1-forced-by-query-param%3Dtrue%7Cfeature2-forced-by-query-param%3Dfalse", fakeHeaders, "body")
+  val request = FakeRequest.apply(
+    "GET",
+    "http://priceestimation.autoscout24.de?toguru=feature-forced-by-query-param%3Dtrue",
+    fakeHeaders,
+    "body")
+  val requestWithToggleIdUpppercased = FakeRequest.apply(
+    "GET",
+    "http://priceestimation.autoscout24.de?toguru=feature-FORCED-by-query-param%3Dtrue",
+    fakeHeaders,
+    "body")
+  val requestWithTwoTogglesInQueryString = FakeRequest.apply(
+    "GET",
+    "http://priceestimation.autoscout24.de?toguru=feature1-forced-by-query-param%3Dtrue%7Cfeature2-forced-by-query-param%3Dfalse",
+    fakeHeaders,
+    "body"
+  )
 
   "Conversion of request header to ClientInfo" should {
 
     "extract culture attribute" in {
       val clientInfo = client(request)
-      clientInfo.attributes.get("culture").value shouldBe "de-DE"
+      clientInfo.attributes.get("culture").value mustBe "de-DE"
     }
 
     "extract of user agent from user agent header" in {
       val clientInfo = client(request)
-      clientInfo.attributes.get(UserAgent).value shouldBe "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+      clientInfo.attributes
+        .get(UserAgent)
+        .value mustBe "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
     }
 
     "extract of uuid from GUID or visitor cookie" in {
       val clientInfo = client(request)
-      clientInfo.uuid.value shouldBe UUID.fromString("a5f409eb-2fdd-4499-b65b-b22bd7e51aa2")
+      clientInfo.uuid.value mustBe UUID.fromString(
+        "a5f409eb-2fdd-4499-b65b-b22bd7e51aa2")
     }
   }
 
   "Forcing feature toggles" should {
     "override feature toggles by http header" in {
-      client(request).forcedToggle("feature1-Forced-By-HEADER").value shouldBe true
-      client(request).forcedToggle("feature2-Forced-By-Header").value shouldBe true
+      client(request)
+        .forcedToggle("feature1-Forced-By-HEADER")
+        .value mustBe true
+      client(request)
+        .forcedToggle("feature2-Forced-By-Header")
+        .value mustBe true
     }
 
     "override feature toggles by cookie" in {
-      client(request).forcedToggle("feature1-Forced-By-COOKIE").value shouldBe true
-      client(request).forcedToggle("feature2-Forced-By-Cookie").value shouldBe true
+      client(request)
+        .forcedToggle("feature1-Forced-By-COOKIE")
+        .value mustBe true
+      client(request)
+        .forcedToggle("feature2-Forced-By-Cookie")
+        .value mustBe true
     }
 
     "override one feature toggle by query param" in {
       val clientInfo: ClientInfo = client(request)
-      clientInfo.forcedToggle("feature-forced-by-query-param").value shouldBe true
+      clientInfo
+        .forcedToggle("feature-forced-by-query-param")
+        .value mustBe true
     }
 
     "override one feature toggle by query param with unusual case" in {
       val clientInfo: ClientInfo = client(requestWithToggleIdUpppercased)
-      clientInfo.forcedToggle("feature-forced-by-query-param").value shouldBe true
+      clientInfo
+        .forcedToggle("feature-forced-by-query-param")
+        .value mustBe true
     }
 
     "override two feature toggles by query param" in {
       val clientInfo: ClientInfo = client(requestWithTwoTogglesInQueryString)
-      clientInfo.forcedToggle("feature1-forced-by-query-param").value shouldBe true
-      clientInfo.forcedToggle("feature2-forced-by-query-param").value shouldBe false
+      clientInfo
+        .forcedToggle("feature1-forced-by-query-param")
+        .value mustBe true
+      clientInfo
+        .forcedToggle("feature2-forced-by-query-param")
+        .value mustBe false
     }
 
     "override one feature toggle twice by query param takes only first occurrence" in {
       val clientInfo: ClientInfo = client(requestWithTwoTogglesInQueryString)
-      clientInfo.forcedToggle("feature1-forced-by-query-param").value shouldBe true
+      clientInfo
+        .forcedToggle("feature1-forced-by-query-param")
+        .value mustBe true
     }
   }
 }

--- a/src/test/scala/toguru/test/TestActivationsSpec.scala
+++ b/src/test/scala/toguru/test/TestActivationsSpec.scala
@@ -3,11 +3,11 @@ package toguru.test
 import org.scalatest._
 import toguru.api._
 
-class TestActivationsSpec extends WordSpec with ShouldMatchers {
+class TestActivationsSpec extends WordSpec with MustMatchers {
 
   "healthy" should {
     "always return true" in {
-      TestActivations()().healthy() shouldBe true
+      TestActivations()().healthy() mustBe true
     }
   }
 
@@ -17,7 +17,7 @@ class TestActivationsSpec extends WordSpec with ShouldMatchers {
       val activationsProvider = TestActivations(toggle -> Condition.On)()
       val activations = activationsProvider()
 
-      activations(toggle) shouldBe Condition.On
+      activations(toggle) mustBe Condition.On
     }
 
     "return the default activations if no activation was given" in {
@@ -25,7 +25,7 @@ class TestActivationsSpec extends WordSpec with ShouldMatchers {
       val activationsProvider = TestActivations()()
       val activations = activationsProvider()
 
-      activations(toggle) shouldBe Condition.On
+      activations(toggle) mustBe Condition.On
     }
   }
 
@@ -33,12 +33,14 @@ class TestActivationsSpec extends WordSpec with ShouldMatchers {
     "return the toggles as given in the test" in {
       val toggle = Toggle("test-toggle")
       val anotherToggle = Toggle("another-toggle")
-      val activations = TestActivations(toggle -> Condition.On, anotherToggle -> Condition.Off)(toggle -> "my-service")
+      val activations =
+        TestActivations(toggle -> Condition.On, anotherToggle -> Condition.Off)(
+          toggle -> "my-service")
 
       val toggles = activations().togglesFor("my-service")
 
-      toggles.size shouldBe 1
-      toggles.get("test-toggle") shouldBe Some(Condition.On)
+      toggles.size mustBe 1
+      toggles.get("test-toggle") mustBe Some(Condition.On)
     }
   }
 }


### PR DESCRIPTION
Hi Team, 

We thought of spiking out the rework needed for upgrading the client to make use of latest play and scala versions. This is not something that you might want to merge directly, since this breaks backwards compatibility. This is only to start moving this effort.

Besides the rework related to update in Play framework, there is another dependency that needs to be compiled to scala 2.12. Scala-circuit-breaker should also be clone/fork internally and has to be published to nexus. 

Speak to us, in the privatesellerlisting slack channel or talk to us: @ebaddeley or @avillalain in slack

Thanks