### PR TITLE
Make activations provider closeable

### DIFF
--- a/core/src/main/scala/toguru/api/Activations.scala
+++ b/core/src/main/scala/toguru/api/Activations.scala
@@ -5,9 +5,8 @@ import toguru.impl.{RemoteActivationsProvider, ToggleState}
 
 object Activations {
 
-  trait Provider {
+  trait Provider extends AutoCloseable {
     def apply(): Activations
-
     def healthy(): Boolean
   }
 

--- a/core/src/main/scala/toguru/impl/RemoteActivationsProvider.scala
+++ b/core/src/main/scala/toguru/impl/RemoteActivationsProvider.scala
@@ -143,10 +143,8 @@ class RemoteActivationsProvider(
     fetchToggleStates(sequenceNo).foreach(ts => currentActivation.set(new ToggleStateActivations(ts)))
   }
 
-  def close(): RemoteActivationsProvider = {
+  def close(): Unit =
     schedule.cancel(true)
-    this
-  }
 
   private[toguru] def fetchToggleStates(sequenceNo: Option[Long]): Option[ToggleStates] = {
 

--- a/core/src/main/scala/toguru/test/TestActivations.scala
+++ b/core/src/main/scala/toguru/test/TestActivations.scala
@@ -11,9 +11,9 @@ object TestActivations {
 
   def apply(activations: (Toggle, Condition)*)(services: (Toggle, String)*): Activations.Provider =
     new Activations.Provider() {
-      override def apply() = new Impl(activations: _*)(services: _*)
-
+      override def apply()   = new Impl(activations: _*)(services: _*)
       override def healthy() = true
+      override def close()   = ()
     }
 
   private[toguru] class Impl(activations: (Toggle, Condition)*)(services: (Toggle, String)*) extends Activations {

--- a/core/src/test/scala/toguru/api/ToguruClientSpec.scala
+++ b/core/src/test/scala/toguru/api/ToguruClientSpec.scala
@@ -15,6 +15,7 @@ class ToguruClientSpec extends AnyFeatureSpec with Matchers with IdiomaticMockit
     new Provider {
       def healthy() = health
       def apply()   = activations
+      def close()   = ()
     }
 
   def toguruClient(

--- a/core/src/test/scala/toguru/impl/RemoteActivationsProviderSpec.scala
+++ b/core/src/test/scala/toguru/impl/RemoteActivationsProviderSpec.scala
@@ -28,8 +28,11 @@ class RemoteActivationsProviderSpec extends AnyWordSpec with OptionValues with M
   def createCircuitBreaker(): CircuitBreaker[Any] =
     new CircuitBreaker[Any]().withFailureThreshold(1000).withDelay(java.time.Duration.ofMillis(100))
 
-  def createProvider(poller: TogglePoller): RemoteActivationsProvider =
-    new RemoteActivationsProvider(poller, executor, circuitBreakerBuilder = createCircuitBreaker).close()
+  def createProvider(poller: TogglePoller): RemoteActivationsProvider = {
+    val provider = new RemoteActivationsProvider(poller, executor, circuitBreakerBuilder = createCircuitBreaker)
+    provider.close()
+    return provider
+  }
 
   def createProvider(
       response: String,


### PR DESCRIPTION
`Activations.fromEndpoint(...)` used to return an `Activations.Provider` that polls the server in the background, but there was no way to stop the polling without casting it to `RemoteActivationsProvider`.