### PR TITLE
Remove a reference to AutoScout24's toguru panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,9 @@ To do this you can
 
 Here is how this would look like for a service included via [nginx server-side includes](http://nginx.org/en/docs/http/ngx_http_ssi_module.html#commands):
 
-### Defining the service or services a toggle belongs to 
-Use `service` or `services` tag to identify all toggles to be passed along. 
-`services` tag expects a string in which service names are separated via commas. (e.g. `"services": "service1,service2,service3"`)
-You can edit toggle tags at https://toguru-panel.tools.autoscout24.com/#/ 
+### Defining the service or services a toggle belongs to
+Use `service` or `services` tag to identify all toggles to be passed along.
+`services` tag expects a string in which service names are separated via commas (e.g. `"services": "service1,service2,service3"`).
 Let's assume, we have some toggles defined as shown below. First three of them are related to `owning-service`
 ```json
 {
@@ -116,8 +115,8 @@ Let's assume, we have some toggles defined as shown below. First three of them a
 ```
 
 ### Passing the toggle state
-The library has already the function to build toggle string 
-for a given service name (it takes only `service` and `services` tags into consideration). 
+The library has already the function to build toggle string
+for a given service name (it takes only `service` and `services` tags into consideration).
 See the examples below:
 ```scala
   import toguru.implicits.toggle._
@@ -236,7 +235,7 @@ val client: PlayClientProvider = { implicit request =>
 ```
 
 By this, the activation of a toggle can be controlled based on the value of
-custom attributes. 
+custom attributes.
 
 In Toguru you would configure:
 ```


### PR DESCRIPTION
I guess the URL of the toguru panel used by AutoScout24 is not a big secret, but anyway it makes no sense to have it referenced in the README of a public repository.