### PR TITLE
Do not publish snapshots to BinTray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ after_success:
   - sbt ++$TRAVIS_SCALA_VERSION coveralls
   - >
     if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_REPO_SLUG" = "Scout24/toguru-scala-client" ]; then
-      if [ "$TRAVIS_BRANCH" == "master" ] || [[ $TRAVIS_TAG ]]; then
+      if [[ $TRAVIS_TAG ]]; then
         ./publish-bintray-release.sh;
       fi
     fi


### PR DESCRIPTION
This was temporarily enabled because people wanted to have artifacts built for other scala and play versions, but it makes the version badge broken. After 3.0.0 release we shouldn't publish snapshots anymore, at least not to the same repository as releases.

If someone still needs snapshots, we should either create a second repository on BinTray, or maybe consider using GitHub Packages for this purpose.