### PR TITLE
Fix buildForwardingToggleString not adding forced toggles correctly

### DIFF
--- a/core/src/test/scala/toguru/api/TogglingSpec.scala
+++ b/core/src/test/scala/toguru/api/TogglingSpec.scala
@@ -83,12 +83,14 @@ class TogglingSpec extends AnyFeatureSpec with Matchers {
   Feature("Can build toggle strings with the minimal set of toggles required to be sent upstream") {
 
     Scenario("considers forced toggles or service tagged ones that are not fully rolled out or rolled off") {
+      val forcedToggle            = Toggle("forced")
       val fullyRolledOutToggle    = Toggle("fullyRolledOut")
       val fullyRolledOffToggle    = Toggle("fullyRolledOff")
       val beingRolledOutToggle    = Toggle("inProgress")
       val alwaysOnToggle          = Toggle("alwaysOn")
       val belongsToAnotherService = Toggle("anotherService")
       val activations = TestActivations(
+        forcedToggle            -> Condition.Off,
         fullyRolledOutToggle    -> Condition.UuidRange(1 to 100),
         fullyRolledOffToggle    -> Condition.Off,
         beingRolledOutToggle    -> Condition.UuidRange(1 to 57),
@@ -102,12 +104,12 @@ class TogglingSpec extends AnyFeatureSpec with Matchers {
         belongsToAnotherService -> "service3"
       )()
 
-      val clientInfo                    = ClientInfo(None, forceToggleTo("feature1", enabled = true))
+      val clientInfo                    = ClientInfo(None, forceToggleTo(forcedToggle.id, enabled = true))
       implicit val toggleInfo: Toggling = TogglingInfo(clientInfo, activations)
 
       toggleInfo.buildForwardingToggleString(
         Set("service1", "service2")
-      ) mustBe ("inProgress=false|alwaysOn=true")
+      ) mustBe ("forced=true|inProgress=false|alwaysOn=true")
     }
   }
 }


### PR DESCRIPTION
The condition of a toggle can still be `false` even if it's forced to `true`.
So if we use
```
toggle.id -> toggle.condition.applies(client)
```
the function `buildForwardingToggleString` might generate the string in which the forced toggle is `false` even if it's forced to `true`.